### PR TITLE
check for null values before parsing row value

### DIFF
--- a/query.ts
+++ b/query.ts
@@ -22,10 +22,14 @@ export default class Query {
       const parsers = format === "text" ? text : binary;
       const parser = parsers.get(dataTypeID);
       const val = msg.fields[i];
-      row[name] = parser ? parser(val) : val;
+      row[name] = parser && !this.isNullOrUndefined(val) ? parser(val) : val;
     }
 
     this.rows.push(row);
+  }
+
+  private isNullOrUndefined(val: unknown) {
+    return val === null || val === undefined
   }
 
   handleCommandComplete(msg: Message) {


### PR DESCRIPTION
Hi :wave: 

I noticed that when executing a `select` query, the library throws the following error when some of the columns contains null values

![image](https://user-images.githubusercontent.com/16882406/137164300-f7393d54-740b-4c1d-87b1-7a79d6f89c57.png)

so here's a quick fix
